### PR TITLE
🎉 Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [1.1.0](https://github.com/Codycody31/go-vanity/releases/tag/1.1.0) - 2024-04-15
+## [2.0.0](https://github.com/Codycody31/go-vanity/releases/tag/2.0.0) - 2024-04-15
 
 ### ❤️ Thanks to all contributors! ❤️
 
 @Codycody31
+
+### 💥 Breaking changes
+
+- Switch from `config.yaml` to `vanity.yaml` [[#4](https://github.com/Codycody31/go-vanity/pull/4)]
 
 ### 📈 Enhancement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@
 
 ### 📈 Enhancement
 
+- Add DisableRootPackagesPage field to Config struct in config.go [[#3](https://github.com/Codycody31/go-vanity/pull/3)]
 - Update README.md with Go Vanity URL Server configuration example [[#1](https://github.com/Codycody31/go-vanity/pull/1)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [1.1.0](https://github.com/Codycody31/go-vanity/releases/tag/1.1.0) - 2024-04-15
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Codycody31
+
+### 📈 Enhancement
+
+- Update README.md with Go Vanity URL Server configuration example [[#1](https://github.com/Codycody31/go-vanity/pull/1)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.0.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.0.0](https://github.com/Codycody31/go-vanity/releases/tag/2.0.0) - 2024-04-15

### 💥 Breaking changes

- Switch from `config.yaml` to `vanity.yaml` [[#4](https://github.com/Codycody31/go-vanity/pull/4)]

### 📈 Enhancement

- Add DisableRootPackagesPage field to Config struct in config.go [[#3](https://github.com/Codycody31/go-vanity/pull/3)]
- Update README.md with Go Vanity URL Server configuration example [[#1](https://github.com/Codycody31/go-vanity/pull/1)]