### PR TITLE
Switch from `config.yaml` to `vanity.yaml`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 vanity
 vendor
-config.yaml
+vanity.yaml
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ extras/
 /build/
 /dist/
 
-config.yaml
+vanity.yaml
 vanity

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ To run the server:
 ./vanity
 ```
 
-By default, the server utilizes `config.yaml` from the current directory and listens on port 8080. You can access `http://localhost:8080/your-package-path` to test the redirection.
+By default, the server utilizes `vanity.yaml` from the current directory and listens on port 8080. You can access `http://localhost:8080/your-package-path` to test the redirection.
 
 ### Configuration
 
-The server's behavior is controlled through the `config.yaml` file. Here’s an example configuration that specifies the domain and package repositories:
+The server's behavior is controlled through the `vanity.yaml` file. Here’s an example configuration that specifies the domain and package repositories:
 
 ```yaml
 domain: "go.example.com"
@@ -63,6 +63,8 @@ packages:
 - `domain`: Your custom domain for hosting Go packages.
 - `packages`: A list of packages with their paths and repository URLs.
 
+If would would like to ensure the info your are setting is correct: you can either add `# yaml-language-server: $schema=schema/vanity-schema.json` to the top of your `vanity.yaml` file if using VSCode in the project, or you can add `# yaml-language-server: $schema=https://raw.githubusercontent.com/Codycody31/go-vanity/main/schema/vanity-schema.json` to the top of your `vanity.yaml` file if using any other editor or if you don't have the schema locally.
+
 **Environment Variables**:
 
 - `VANITY_CONFIG`: Set this to specify a local path to an alternative configuration file.
@@ -74,8 +76,8 @@ You can set environment variables directly or include them in a startup script:
 
 ```bash
 export VANITY_PORT="8080"
-export VANITY_CONFIG="/path/to/your/config.yaml"
-export VANITY_CONFIG_URL="https://example.com/config.yaml"
+export VANITY_CONFIG="/path/to/your/vanity.yaml"
+export VANITY_CONFIG_URL="https://example.com/vanity.yaml"
 ./vanity
 ```
 
@@ -128,19 +130,19 @@ docker pull insidiousfiddler/vanity
 ### Running the Server with Docker
 
 1. **Using a Local Configuration File**:
-   To run the server using a local configuration file, you can mount the configuration directory to the Docker container. Make sure your `config.yaml` file is in a suitable directory, then use the following command to start the server:
+   To run the server using a local configuration file, you can mount the configuration directory to the Docker container. Make sure your `vanity.yaml` file is in a suitable directory, then use the following command to start the server:
 
    ```bash
    docker run -p 8080:8080 -v /path/to/your/config/directory:/etc/vanity insidiousfiddler/vanity
    ```
 
-   This command mounts your local directory containing the `config.yaml` at `/etc/vanity` inside the container, which is the default path the Docker image expects for the configuration file.
+   This command mounts your local directory containing the `vanity.yaml` at `/etc/vanity` inside the container, which is the default path the Docker image expects for the configuration file.
 
 2. **Using a Remote Configuration File**:
    If you prefer to fetch the configuration from a remote URL, set the `VANITY_CONFIG_URL` environment variable when running the Docker container:
 
    ```bash
-   docker run -p 8080:8080 -e VANITY_CONFIG_URL="https://example.com/config.yaml" insidiousfiddler/vanity
+   docker run -p 8080:8080 -e VANITY_CONFIG_URL="https://example.com/vanity.yaml" insidiousfiddler/vanity
    ```
 
    This setup is useful for centralized configuration management, allowing you to update the configuration without rebuilding or restarting containers manually.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestLoadConfigFromFile(t *testing.T) {
 	// Create a temporary YAML file
-	tempFile, err := os.CreateTemp("", "config.yaml")
+	tempFile, err := os.CreateTemp("", "vanity.yaml")
 	if err != nil {
 		t.Fatalf("Cannot create temporary file: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 			&cli.StringFlag{
 				Name:    "config",
 				EnvVars: []string{"VANITY_CONFIG"}, // [1]
-				Value:   "config.yaml",
+				Value:   "vanity.yaml",
 				Usage:   "Path to config file",
 			},
 			&cli.StringFlag{
@@ -50,7 +50,7 @@ func main() {
 			port := string(":") + c.String("port")
 
 			if configPath == "" && c.Bool("in-container") {
-				configPath = "/etc/vanity/config.yaml"
+				configPath = "/etc/vanity/vanity.yaml"
 			}
 
 			cfg, err := config.LoadConfig(configPath, configURL)

--- a/schema/vanity-schema.json
+++ b/schema/vanity-schema.json
@@ -1,51 +1,40 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "domain": {
-            "type": "string",
-            "description": "The custom domain for hosting Go packages."
-        },
-        "disableRootPackagesPage": {
-            "type": "boolean",
-            "description": "Flag to disable the root page that lists all packages."
-        },
-        "packages": {
-            "type": "array",
-            "description": "List of packages with their paths, repositories, and version control systems.",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "The path used to import the Go package."
-                    },
-                    "repo": {
-                        "type": "string",
-                        "description": "URL of the repository where the Go package is hosted."
-                    },
-                    "vcs": {
-                        "type": "string",
-                        "description": "Version control system type.",
-                        "enum": [
-                            "git",
-                            "hg",
-                            "svn"
-                        ]
-                    }
-                },
-                "required": [
-                    "path",
-                    "repo",
-                    "vcs"
-                ],
-                "additionalProperties": false
-            }
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "domain": {
+      "type": "string",
+      "description": "The custom domain for hosting Go packages."
     },
-    "required": [
-        "domain",
-        "packages"
-    ],
-    "additionalProperties": false
+    "disableRootPackagesPage": {
+      "type": "boolean",
+      "description": "Flag to disable the root page that lists all packages."
+    },
+    "packages": {
+      "type": "array",
+      "description": "List of packages with their paths, repositories, and version control systems.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The path used to import the Go package."
+          },
+          "repo": {
+            "type": "string",
+            "description": "URL of the repository where the Go package is hosted."
+          },
+          "vcs": {
+            "type": "string",
+            "description": "Version control system type.",
+            "enum": ["git", "hg", "svn"]
+          }
+        },
+        "required": ["path", "repo", "vcs"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["domain", "packages"],
+  "additionalProperties": false
 }

--- a/schema/vanity-schema.json
+++ b/schema/vanity-schema.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "domain": {
+            "type": "string",
+            "description": "The custom domain for hosting Go packages."
+        },
+        "disableRootPackagesPage": {
+            "type": "boolean",
+            "description": "Flag to disable the root page that lists all packages."
+        },
+        "packages": {
+            "type": "array",
+            "description": "List of packages with their paths, repositories, and version control systems.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path used to import the Go package."
+                    },
+                    "repo": {
+                        "type": "string",
+                        "description": "URL of the repository where the Go package is hosted."
+                    },
+                    "vcs": {
+                        "type": "string",
+                        "description": "Version control system type.",
+                        "enum": [
+                            "git",
+                            "hg",
+                            "svn"
+                        ]
+                    }
+                },
+                "required": [
+                    "path",
+                    "repo",
+                    "vcs"
+                ],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [
+        "domain",
+        "packages"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
This is a breaking change, switching the config file name will result in existing instances not manually setting the path to the file to no longer work.