### PR TITLE
🎉 Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.0](https://github.com/Codycody31/go-vanity/releases/tag/2.1.0) - 2024-04-15
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Codycody31
+
+### 📈 Enhancement
+
+- Add release-config.ts file [[#6](https://github.com/Codycody31/go-vanity/pull/6)]
+
 ## [2.0.0](https://github.com/Codycody31/go-vanity/releases/tag/2.0.0) - 2024-04-15
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.1](https://github.com/Codycody31/go-vanity/releases/tag/2.1.1) - 2024-04-15
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Codycody31
+
+### 🐛 Bug Fixes
+
+- Update build commands in Makefile for release [[#9](https://github.com/Codycody31/go-vanity/pull/9)]
+
 ## [2.1.0](https://github.com/Codycody31/go-vanity/releases/tag/2.1.0) - 2024-04-15
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.1.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.1.1](https://github.com/Codycody31/go-vanity/releases/tag/2.1.1) - 2024-04-15

### 🐛 Bug Fixes

- Update build commands in Makefile for release [[#9](https://github.com/Codycody31/go-vanity/pull/9)]